### PR TITLE
fix missing executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "",
   "scripts": {
     "webpack": "node ./node_modules/webpack/bin/webpack --config webpack.config.js --display-error-details --progress --profile --color",
-    "build": "npm run webpack && extractinfo"
+    "build": "npm run webpack && extractInfo"
   },
   "author": "Pickysaurus",
   "license": "GPL-3.0",


### PR DESCRIPTION
`xx /bin/sh: line 1: extractinfo: command not found`